### PR TITLE
Fix for missing environment configuration

### DIFF
--- a/ansible/roles/adminsite_config/files/etc/httpd/conf/xmladmin.httpd.conf.j2
+++ b/ansible/roles/adminsite_config/files/etc/httpd/conf/xmladmin.httpd.conf.j2
@@ -190,7 +190,7 @@ LoadModule version_module modules/mod_version.so
 #
 # Load config files from the config directory "/etc/httpd/conf.d".
 #
-#Include conf.d/xmladm_perl.conf
+Include conf.d/xmladmin_perl.conf
 
 #
 # ExtendedStatus controls whether Apache will generate "full" status


### PR DESCRIPTION
The current production instance of XML Admin (input) is missing critical environment configuration and is functional only due to a manual workaround that was added to the `xmladmin.cgi` handler; these changes ensure that the correct configuration is present and removes the need for the previously implemented workaround.