### PR TITLE
Update env var in xmladmin httpd conf

### DIFF
--- a/ansible/roles/adminsite_config/files/etc/httpd/conf/xmladmin.httpd.conf.j2
+++ b/ansible/roles/adminsite_config/files/etc/httpd/conf/xmladmin.httpd.conf.j2
@@ -319,7 +319,7 @@ DocumentRoot "/home/xmladm/htdocs"
 #</Directory>
 
 ### XMLADMIN ### XMLADMIN ### XMLADMIN ### XMLADMIN ### XMLADMIN ### XMLADMIN ### XMLADMIN ### XMLADMIN ### 
-    SetEnv ORACLE_HOME /usr/local/oracle/product/10.2.0
+    SetEnv TNS_ADMIN /usr/lib/oracle/11.2/client64/lib
 
     Alias /images/ "/home/xmladm/htdocs/images/"
     <Directory "/home/xmladm/htdocs/images">


### PR DESCRIPTION
Update the env var to set the TNS_ADMIN path, so that Oracle tnsnames.ora can be found by the xml admin app.

Resolves
https://companieshouse.atlassian.net/browse/DVOP-2796