### PR TITLE
Replace unnecessary mod_imap module with mod_auth_digest

### DIFF
--- a/ansible/roles/adminsite_config/files/etc/httpd/conf/chdadmin.httpd.conf.j2
+++ b/ansible/roles/adminsite_config/files/etc/httpd/conf/chdadmin.httpd.conf.j2
@@ -150,7 +150,7 @@ LoadModule auth_digest_module modules/mod_auth_digest.so
 LoadModule authn_file_module modules/mod_authn_file.so
 LoadModule authn_anon_module modules/mod_authn_anon.so
 LoadModule authn_dbm_module modules/mod_authn_dbm.so
-LoadModule imap_module modules/mod_imap.so
+LoadModule auth_digest_module modules/mod_auth_digest.so
 LoadModule ldap_module modules/mod_ldap.so
 LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
 LoadModule include_module modules/mod_include.so


### PR DESCRIPTION
This change removes the `mod_imap` Apache module, as image maps are not used by this service and the missing shared library causes Apache to fail at startup.