### PR TITLE
Update Apache HTTP Server configs

### DIFF
--- a/ansible/roles/adminsite_config/files/etc/httpd/conf/chdadmin.httpd.conf.j2
+++ b/ansible/roles/adminsite_config/files/etc/httpd/conf/chdadmin.httpd.conf.j2
@@ -150,7 +150,6 @@ LoadModule auth_digest_module modules/mod_auth_digest.so
 LoadModule authn_file_module modules/mod_authn_file.so
 LoadModule authn_anon_module modules/mod_authn_anon.so
 LoadModule authn_dbm_module modules/mod_authn_dbm.so
-LoadModule imap_module modules/mod_imap.so
 LoadModule ldap_module modules/mod_ldap.so
 LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
 LoadModule include_module modules/mod_include.so

--- a/ansible/roles/adminsite_config/files/etc/httpd/conf/ewfadmin.httpd.conf.j2
+++ b/ansible/roles/adminsite_config/files/etc/httpd/conf/ewfadmin.httpd.conf.j2
@@ -149,7 +149,6 @@ LoadModule auth_digest_module modules/mod_auth_digest.so
 LoadModule authn_file_module modules/mod_authn_file.so
 LoadModule authn_anon_module modules/mod_authn_anon.so
 LoadModule authn_dbm_module modules/mod_authn_dbm.so
-LoadModule auth_digest_module modules/mod_auth_digest.so
 LoadModule ldap_module modules/mod_ldap.so
 LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
 LoadModule include_module modules/mod_include.so

--- a/ansible/roles/adminsite_config/files/etc/httpd/conf/xmladmin.httpd.conf.j2
+++ b/ansible/roles/adminsite_config/files/etc/httpd/conf/xmladmin.httpd.conf.j2
@@ -149,7 +149,6 @@ LoadModule auth_digest_module modules/mod_auth_digest.so
 LoadModule authn_file_module modules/mod_authn_file.so
 LoadModule authn_anon_module modules/mod_authn_anon.so
 LoadModule authn_dbm_module modules/mod_authn_dbm.so
-LoadModule auth_digest_module modules/mod_auth_digest.so
 LoadModule ldap_module modules/mod_ldap.so
 LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
 LoadModule include_module modules/mod_include.so

--- a/ansible/roles/adminsite_config/files/etc/httpd/conf/xmloutadmin.httpd.conf.j2
+++ b/ansible/roles/adminsite_config/files/etc/httpd/conf/xmloutadmin.httpd.conf.j2
@@ -149,7 +149,6 @@ LoadModule auth_digest_module modules/mod_auth_digest.so
 LoadModule authn_file_module modules/mod_authn_file.so
 LoadModule authn_anon_module modules/mod_authn_anon.so
 LoadModule authn_dbm_module modules/mod_authn_dbm.so
-LoadModule auth_digest_module modules/mod_auth_digest.so
 LoadModule ldap_module modules/mod_ldap.so
 LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
 LoadModule include_module modules/mod_include.so


### PR DESCRIPTION
This change cleans up the Apache HTTP Server configuration files to improve correctness:

- Remove duplicate `LoadModule` directives to ensure the configuration files are syntactically correct, resolving warnings observed when running `apachectl configtest`.
- Remove the `mod_imap` module from the CHD Admin service configuration. Image maps are not used by this service, and the absence of the corresponding shared library causes Apache to fail at startup.